### PR TITLE
Refactor image upload process 

### DIFF
--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -33,7 +33,7 @@ const toastVariants = cva(
         warning:
             "border-amber-200 dark:border-amber-900/50 bg-amber-50 dark:bg-amber-900/40 text-amber-900 dark:text-amber-200 shadow-amber-200/20 dark:shadow-none",
         destructive:
-          "border-red-200 dark:border-red-500/50 bg-red-50 dark:bg-red-900/30 text-red-900 dark:text-red-50 shadow-red-200/20 dark:shadow-none",
+          "border-red-200 dark:border-red-400 bg-red-50 dark:bg-red-800/95 text-red-900 dark:text-white shadow-red-200/20 dark:shadow-[0_0_0_1px_rgba(248,113,113,0.5),0_4px_20px_rgba(0,0,0,0.4)]",
       },
     },
     defaultVariants: {

--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -29,7 +29,7 @@ export function Toaster() {
       case "warning":
         return "w-8 h-8 rounded-full bg-amber-100 dark:bg-amber-900/30 flex items-center justify-center text-amber-600 shrink-0"
       case "destructive":
-        return "w-8 h-8 rounded-full bg-red-100 dark:bg-red-900/30 flex items-center justify-center text-red-600 shrink-0"
+        return "w-8 h-8 rounded-full bg-red-100 dark:bg-red-600/90 flex items-center justify-center text-red-600 dark:text-white shrink-0"
       default:
         return "w-8 h-8 rounded-full bg-indigo-100 dark:bg-indigo-900/30 flex items-center justify-center text-indigo-600 shrink-0"
     }


### PR DESCRIPTION
This pull request improves the image upload flow to Supabase Storage and refines the UI feedback for destructive toasts. The upload endpoint now avoids generating a read URL before the file exists, preventing errors, and the client logic is updated to handle the two-step upload and retrieval process. Additionally, the appearance of destructive toasts is enhanced for better clarity in both light and dark modes.

**Image upload flow improvements:**

* The `/api/analytics/upload-image` endpoint now only returns an upload token/path for new files; it no longer tries to generate a read URL before the file exists, preventing 500 errors. Clients must now make a second call to retrieve the read URL after uploading. [[1]](diffhunk://#diff-15ae4421cdf9ef75a785b55f70c7cf7833ef7740abef21a79559cb810caf2ef7L6-R8) [[2]](diffhunk://#diff-15ae4421cdf9ef75a785b55f70c7cf7833ef7740abef21a79559cb810caf2ef7L35-R35) [[3]](diffhunk://#diff-15ae4421cdf9ef75a785b55f70c7cf7833ef7740abef21a79559cb810caf2ef7L48-R67)
* The client-side logic in `BillSplitterFlow` is updated to handle the two-step upload: it first uploads the file, then, if needed, makes a second request to get the read URL. [[1]](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bR710-R714) [[2]](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bR732-R747)

**UI improvements for destructive toasts:**

* The `toast.tsx` and `toaster.tsx` components update the styling for destructive toasts, improving contrast and visibility in dark mode and adding a more prominent shadow. [[1]](diffhunk://#diff-c0d5b8ec90d6ad2f9428321a5f778ac03c2e653489e38f0b55931f8edb8712b4L36-R36) [[2]](diffhunk://#diff-833308ed4183cdb0493ed4c391a973210ff1f2ade37028b2b3ea9ab16b6c1b57L32-R32)